### PR TITLE
Fix typo causing "name 'jsoin' is not defined" error

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -1117,7 +1117,7 @@ class WebRTCClient:
                                     printwout(msg)
                                     await self.conn.send(msg)
                                 else:
-                                    msg = jsoin.dumps({"request":"seed","streamID":self.stream_id+self.hashcode}) ## we're just going to publish a stream
+                                    msg = json.dumps({"request":"seed","streamID":self.stream_id+self.hashcode}) ## we're just going to publish a stream
                                     printwout("seed start")
                                     await self.conn.send(msg)
                     continue


### PR DESCRIPTION
This fixes a typo which causes the error `name 'jsoin' is not defined`  to be printed when publishing a stream.