### PR TITLE
audio fix for raspininja.service?

### DIFF
--- a/raspberry_pi/raspininja.service
+++ b/raspberry_pi/raspininja.service
@@ -1,18 +1,31 @@
 [Unit]
 Description=Raspberry Ninja as a system service
-After=network-online.target
+After=network-online.target sound.target
+Wants=sound.target
 Requires=network-online.target
 
 [Service]
+# Run as 'vdo' user and group, ensure this user has the necessary permissions
 User=vdo
 Group=vdo
-Type=idle
+
+# Using 'simple' type for immediate start-up, consider if 'idle' is necessary
+Type=simple
+
+# Ensuring the environment has necessary variables for audio, adjust as needed
+Environment="XDG_RUNTIME_DIR=/run/user/1000"
+Environment="PULSE_SERVER=/run/user/1000/pulse/native"
+
+# Sleep to ensure all dependencies are up, and check camera availability
 ExecStartPre=/bin/sleep 5
+ExecStartPre=/usr/bin/vcgencmd get_camera
+
+# Main command to start the service, adjust path and options as necessary
+ExecStart=/usr/bin/python3 /home/vdo/raspberry_ninja/publish.py --test
+
+# Restart policy
 Restart=always
 RestartSec=5s
-Environment=XDG_RUNTIME_DIR=/run/user/1000
-ExecStartPre=vcgencmd get_camera
-ExecStart=/usr/bin/python3 /home/vdo/raspberry_ninja/publish.py --test
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This updated script includes environment variables that might be needed for PulseAudio, IT IS UNTESTED

ChatGPT notes below. 

Important Adjustments and Considerations:
After and Wants: Added sound.target to the After= and Wants= directives to ensure that the sound system is fully initialized before your service starts. This is particularly important for ensuring that audio devices are ready and accessible.

Environment Variables: The PULSE_SERVER environment variable is set to point to the PulseAudio server for the vdo user. This assumes that your Raspberry Pi OS uses PulseAudio and that 1000 is the correct user ID for vdo. Adjust this if your setup is different.

Permissions: Make sure that the vdo user is in the audio group to have the necessary permissions to access audio devices:

bash
Copy code
sudo usermod -a -G audio vdo
This command adds the vdo user to the audio group. You may need to log out and log back in or restart for these changes to take effect.

Service Type: Changed Type=idle to Type=simple. This is a minor adjustment and may not be necessary for your specific case, but simple is the default and generally works well for services that don't need to wait on other units to fully start up. If your service specifically benefits from Type=idle, you might consider switching it back.

Camera Access: The inclusion of vcgencmd get_camera in ExecStartPre ensures that the camera is available before starting the service. If this command fails, the service will not start. Ensure this command works as expected under the vdo user.

This service file should be placed in /etc/systemd/system/, with a filename that reflects your service's purpose, such as raspberry_ninja.service. After placing the file, remember to reload the systemd daemon and enable your service:

bash
Copy code
sudo systemctl daemon-reload
sudo systemctl enable raspberry_ninja.service
sudo systemctl start raspberry_ninja.service
Check the status of your service and system logs if you encounter any issues:

bash
Copy code
sudo systemctl status raspberry_ninja.service
journalctl -u raspberry_ninja.service
These commands help diagnose issues by providing the service's current status and its logs, respectively.